### PR TITLE
Fix question delete

### DIFF
--- a/guidedmodules/views.py
+++ b/guidedmodules/views.py
@@ -1891,7 +1891,6 @@ def authoring_edit_question2(request):
 
     question = get_object_or_404(ModuleQuestion.objects.select_related('module'), id=request.POST['q_id'])
     module = question.module
-
     # Delete the question?
     if request.POST.get("delete") == "1":
         try:
@@ -1899,7 +1898,7 @@ def authoring_edit_question2(request):
             return JsonResponse({ "status": "ok", "redirect": task.get_absolute_url() })
         except Exception as e:
             # The only reason it would fail is a protected foreign key.
-            return JsonResponse({ "status": "error", "message": "The question cannot be deleted because it has already been answered." })
+            return JsonResponse({ "status": "error", "message": "The question #"+request.POST['q_id']+" cannot be deleted because it has been answered in a Project. Contact an administrator to delete." })
 
     # Update the question...
     # Update the key.

--- a/siteapp/static/js/authoring_tool.js
+++ b/siteapp/static/js/authoring_tool.js
@@ -237,14 +237,16 @@ function authoring_tool_save_question() {
 
 function authoring_tool_delete_question() {
   if (!confirm("Are you sure you want to delete this question?")) return;
+  var data = $('#question_authoring_tool form').serializeArray();
+  if (q_authoring_tool_state.task) {
+    data.push( { name: "task", value: q_authoring_tool_state.task } );
+  }
+  data.push( { name: "question", value: q_authoring_tool_state.current_question } );
+  data.push( { name: "delete", value: 1 } );
   ajax_with_indicator({
-      url: "/tasks/_authoring_tool/edit-question",
+      url: "/tasks/_authoring_tool/edit-question2",
       method: "POST",
-      data: {
-        task: q_authoring_tool_state.task,
-        question: q_authoring_tool_state.current_question,
-        delete: 1
-      },
+      data: data,
       keep_indicator_forever: true, // keep the ajax indicator up forever --- it'll go away when we issue the redirect
       success: function(res) {
         // Modal can stay up until the redirect finishes.


### PR DESCRIPTION
Question "Delete Question" button was not working on authoring tool. The related Javascript AJAX call was pointed to the old path for editing a question and was not passing data correctly. This has been fixed. 