### PR TITLE
Fix for Mac AMD/M1 chip with Dockerfile.m1 skippining Chromium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Release adds support for private components and integrations with third party se
 * Refactor and OIDC authentication for proper testing of admin and not admin roles.
 * Create a new system via name given by a string in URL.
 * Add a large set of sample components (150+) generated from STIGs.
+* Detect Apple ARM platform (e.g. 'M1 chip') and use alternate backend Dockerfile with Chromium install commented out.
 
 **Bug fixes**
 

--- a/dev_env/README.md
+++ b/dev_env/README.md
@@ -18,6 +18,12 @@ For Docker version 20.x on MacOS, disable docker-compose v-2 to avoid blocking a
 docker-compose disable-v2
 ```
 
+## AMD64 Mac (M1 Chipset) Notes
+
+By default, the dev_en install for local development will detect the Apple ARM platform and launch a Docker image (Dockerfile.M1) that skips the installation of the Chromium driver for UI tests with Selenium that is incompatible with AMD64 Mac (M1 Chipset). 
+
+To instead include the Chromium driver and run the Docker container under emulation use the `--amd` flag described below. Be forewarned that the application  runs _significantly_ slower in this mode.
+
 ## How To
 1. Configure
 
@@ -30,7 +36,7 @@ docker-compose disable-v2
 2. Start
     - `python run.py dev`         : This will run + reuse previously built artifacts (database, files, etc)
     - `python run.py dev --clean` : This will run + destroys your existing database and artifacts from previous runs
-    - `python run.py dev --amd`   : This will run + build for the m1 chipset.  Make sure to change your 
+    - `python run.py dev --amd`   : This will run + build for the AMD64 M1 chipset in emulation, but application will run slowly.  Make sure to change your 
       environment.json to `"test_browser": "firefox"`
     
 3. Stop

--- a/dev_env/docker/docker-compose.yml
+++ b/dev_env/docker/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     container_name: govready-q-dev
     build:
       context: ../..
-      dockerfile: dev_env/docker/images/backend/Dockerfile
+      dockerfile: dev_env/docker/images/backend/${BACKEND_DOCKERFILE}
     command: /bin/bash -c /usr/src/app/dev_env/docker/images/backend/docker-entrypoint.sh
     volumes:
       - ../..:/usr/src/app

--- a/dev_env/docker/images/backend/Dockerfile.M1
+++ b/dev_env/docker/images/backend/Dockerfile.M1
@@ -1,0 +1,59 @@
+# Ubuntu 20.04 focal-20210119
+FROM ubuntu:focal-20210119
+
+# Update package list.
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Set up the locale.
+RUN apt-get update && \
+  apt-get install -y locales openssh-sftp-server openssh-server xvfb libfontconfig libmariadbclient-dev && \
+  echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
+  dpkg-reconfigure locales && \
+  update-locale LANG=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+
+RUN echo "root:root" | chpasswd && \
+  mkdir /var/run/sshd
+
+# Set up the timezone.
+RUN apt-get update && apt-get install -y --no-install-recommends tzdata && \
+  ln -fs /usr/share/zoneinfo/UTC /etc/localtime && \
+  dpkg-reconfigure tzdata
+
+# Install GovReady-Q prerequisites.
+RUN apt-get update && apt-get -y install \
+  unzip git curl jq \
+  python3 python3-pip \
+  python3-yaml \
+  graphviz pandoc \
+  gunicorn
+
+ENV CHROME_VERSION "google-chrome-stable"
+RUN sed -i -- 's&deb http://deb.debian.org/debian jessie-updates main&#deb http://deb.debian.org/debian jessie-updates main&g' /etc/apt/sources.list \
+  && apt-get update && apt-get install wget -y
+ENV CHROME_VERSION "google-chrome-stable"
+#RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+#  && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list \
+#  && apt-get update && apt-get -qqy install ${CHROME_VERSION:-google-chrome-stable}
+
+# Chromium for Headless Selenium tests
+#RUN wget -O /tmp/chromedriver.zip http://chromedriver.storage.googleapis.com/`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE`/chromedriver_linux64.zip \
+#    && unzip /tmp/chromedriver.zip chromedriver -d /usr/local/bin/
+ENV DISPLAY=:99
+
+# Put the Python source code here.
+WORKDIR /usr/src/app
+
+RUN apt-get update && apt-get install -y wkhtmltopdf;
+
+# Upgrade pip to version 20.1+ - IMPORTANT
+RUN python3 -m pip install --upgrade pip
+RUN pip3 install ipdb
+
+# This directory must be present for the AppSource created by our
+# first_run script. The directory only has something in it if
+# the container is launched with --mount.
+# --mount type=bind,source="$(pwd)",dst=/mnt/q-files-host
+RUN mkdir -p /mnt/q-files-host


### PR DESCRIPTION
Create separate Dockerfile.M1 for backend that skips the Chromium
files that do not run on M1 chips. Adjust docker-compose-yml file
to auto choose correct version of Dockerfile based on processor.

This enables development on M1 withou poor performance of compatibility
mode, but ability to run auomated tests locally is lost.