### PR TITLE
Develop aspen create system screens

### DIFF
--- a/controls/views.py
+++ b/controls/views.py
@@ -3964,7 +3964,37 @@ def create_system_from_string(request):
 
     # Display form when no string received
     if new_system_str is None:
-        context = {}
+
+        # Get the app catalog. If the user is answering a question, then filter to
+        # just the apps that can answer that question.
+        from siteapp.views import filter_app_catalog
+        catalog, filter_description = filter_app_catalog(get_compliance_apps_catalog_for_user(request.user), request)
+        # Group by category from catalog metadata.
+        from collections import defaultdict
+        catalog_by_category = defaultdict(lambda: {"title": None, "apps": []})
+        for app in catalog:
+            source_slug, _ = app["key"].split('/')
+            app['source_slug'] = source_slug
+            # print(f"1 keys: {app.keys()}")
+            # print(f"2 key, title: {app['key']}, {app['title']}")
+            for category in app["categories"]:
+                catalog_by_category[category]["title"] = (category or "Uncategorized")
+                # Test for inclusion here...
+                from siteapp.models import Organization
+                organization = Organization.objects.first()  # temporary
+                # if app['title'] in ['Blank Project', 'Speedy SSP', 'General IT System ATO for 800-53 (low)']:
+                if app['title'] in organization.extra.get('default_appversion_name_list', []): # temporary
+                    catalog_by_category[category]["apps"].append(app)
+
+        # Sort categories by title and discard keys.
+        catalog_by_category = sorted(catalog_by_category.values(), key=lambda category: (
+            category["title"] != "Great starter apps",  # this category goes first
+            category["title"].lower(),  # sort case insensitively
+            category["title"],  # except if two categories differ only in case, sort case-sensitively
+        ))
+        context = {
+            "apps": catalog_by_category
+        }
         return render(request, "systems/new_system_form.html", context)
 
     new_system_name = new_system_str
@@ -4054,8 +4084,8 @@ def create_system_from_string(request):
     messages.add_message(request, messages.INFO, new_system_msg)
 
     # Redirect to the new system/project.
-    return HttpResponseRedirect(project.get_absolute_url())   
-    # return HttpResponseRedirect(f"/system/{new_system.id}/aspen/summary")
+    # return HttpResponseRedirect(project.get_absolute_url())
+    return HttpResponseRedirect(f"/system/{new_system.id}/aspen/summary")
 
 @login_required
 def system_summary_1_aspen(request, system_id):

--- a/controls/views.py
+++ b/controls/views.py
@@ -3979,8 +3979,8 @@ def create_system_from_string(request):
             # print(f"2 key, title: {app['key']}, {app['title']}")
             for category in app["categories"]:
                 catalog_by_category[category]["title"] = (category or "Uncategorized")
-                # Test for inclusion here...
-                from siteapp.models import Organization
+                # Only get default apps
+                # TODO: Refactor this code
                 organization = Organization.objects.first()  # temporary
                 # if app['title'] in ['Blank Project', 'Speedy SSP', 'General IT System ATO for 800-53 (low)']:
                 if app['title'] in organization.extra.get('default_appversion_name_list', []): # temporary
@@ -4085,7 +4085,7 @@ def create_system_from_string(request):
 
     # Redirect to the new system/project.
     # return HttpResponseRedirect(project.get_absolute_url())
-    return HttpResponseRedirect(f"/system/{new_system.id}/aspen/summary")
+    return redirect(reverse('system_summary', args=[new_system.id]))
 
 @login_required
 def system_summary_1_aspen(request, system_id):

--- a/integrations/csam/views.py
+++ b/integrations/csam/views.py
@@ -435,8 +435,8 @@ def create_system_from_remote(request):
         messages.add_message(request, messages.INFO, f"Created new System in GovReady based on {INTEGRATION_NAME} system id {csam_system_id}.")
 
         # Redirect to the new system/project.
-        # return HttpResponseRedirect(project.get_absolute_url())   
-        return HttpResponseRedirect(f"/system/{new_system.id}/aspen/summary")
+        # return HttpResponseRedirect(project.get_absolute_url())
+        return redirect(reverse('system_summary', args=[new_system.id]))
     else:
         systems = System.objects.filter(Q(info__contains={"csam_system_id": csam_system_id}))
         if len(systems) == 1:

--- a/integrations/grc/views.py
+++ b/integrations/grc/views.py
@@ -424,8 +424,8 @@ def create_system_from_remote(request):
         messages.add_message(request, messages.INFO, f"Created new System in GovReady based on {INTEGRATION_NAME} system id {csam_system_id}.")
 
         # Redirect to the new system/project.
-        # return HttpResponseRedirect(project.get_absolute_url())   
-        return HttpResponseRedirect(f"/system/{new_system.id}/aspen/summary")
+        # return HttpResponseRedirect(project.get_absolute_url())
+        return redirect(reverse('system_summary', args=[new_system.id]))
     else:
         systems = System.objects.filter(Q(info__contains={"csam_system_id": csam_system_id}))
         if len(systems) == 1:

--- a/siteapp/management/commands/first_run.py
+++ b/siteapp/management/commands/first_run.py
@@ -42,6 +42,16 @@ class Command(BaseCommand):
         if not Organization.objects.all().exists() and not Organization.objects.filter(name="main").exists():
             org = Organization.objects.create(name="main", slug="main")
 
+        # Set values for default apps (templates) for Aspen new system page
+        if "default_appversion_name_list" not in org.extra:
+            org.extra["default_appversion_name_list"] = [
+                "Blank Project",
+                "Speedy SSP",
+                "General IT System ATO for 800-53 (low)"
+            ]
+            org.save()
+        ["Blank Project", "Speedy SSP", "General IT System ATO for 800-53 (low)"]
+
         # Create GovReady admin users, if specified in local/environment.json
         if len(settings.GOVREADY_ADMINS):
             for admin_user in settings.GOVREADY_ADMINS:

--- a/siteapp/static/css/govready-q.css
+++ b/siteapp/static/css/govready-q.css
@@ -183,7 +183,7 @@ a:focus-visible {
 
 /* within navbar and base.html */
 .navbar-brand img { margin: -1px 20px; width:160px; }
-.dropdown-menu { width: 150px; }
+.dropdown-menu { width: 220px; }
 .nav-dropdown-item-text { margin: 0px 12px 8px 20px; }
 .nav-profile { margin: -5px 5px; }
 .message-margin { margin-top: 0em; margin-bottom: 0px; padding: 0px; position:absolute; right: 0px; top: 52px; z-index: 100; width: 340px;}

--- a/siteapp/views.py
+++ b/siteapp/views.py
@@ -19,6 +19,7 @@ from django.http import (Http404, HttpResponse, HttpResponseForbidden,
                          HttpResponseRedirect)
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
+from django.urls import reverse
 from django.views.decorators.http import require_http_methods
 from django.views.generic import ListView
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -510,7 +511,9 @@ def apps_catalog(request):
                 return HttpResponseRedirect(url)
 
             # Redirect to the new project.
-            return HttpResponseRedirect(project.get_absolute_url())
+            # return HttpResponseRedirect(project.get_absolute_url())
+            new_system = project.system
+            return redirect(reverse('system_summary', args=[new_system.id]))
 
     return render(request, "app-store.html", {
         "apps": catalog_by_category,
@@ -609,7 +612,9 @@ def apps_catalog_item(request, source_slug, app_name):
                     task.get_absolute_url() + "#" + urlencode({"q": q.key, "t": project.root_task.id}))
 
             # Redirect to the new project.
-            return HttpResponseRedirect(project.get_absolute_url())
+            # return HttpResponseRedirect(project.get_absolute_url())
+            new_system = project.system
+            return redirect(reverse('system_summary', args=[new_system.id]))
 
     # Show the "app" page.
     return render(request, "app-store-item.html", {

--- a/templates/base.html
+++ b/templates/base.html
@@ -52,7 +52,8 @@
     <!--[if lt IE 8]><p>Internet Explorer version 8 or any modern web browser is required to use this website, sorry.<![endif]-->
     <!--[if gt IE 7]><!-->
 
-    {% include "navbar.html" %}
+    {# include "navbar.html" #}
+    {% include "summary_navbar.html" %}
 
     {% block contextbar %}
     <div id="context-bar">

--- a/templates/portfolios/detail.html
+++ b/templates/portfolios/detail.html
@@ -44,7 +44,7 @@ Remove contextbar from top of page
     <div class="container">
       <div class="row">
         <!-- <div class="col-sm-1">&nbsp;</div> -->
-        <div class="col-xs-10 col-md-4">Project</div>
+        <div class="col-xs-10 col-md-4">System</div>
         <div class="col-xs-6 col-sm-1">ID</div>
         <div class="col-xs-6 col-sm-3">Portfolio</div>
         <div class="col-xs-6 col-sm-2">Role</div>
@@ -66,7 +66,7 @@ Remove contextbar from top of page
         </div> -->
 
         <div class="col-xs-10 col-md-4">
-          <a href="{{project.get_absolute_url}}" class="portfolio-project-link">{{project.title|truncatechars:60}}</a>
+          <a href="{% url 'system_summary' system_id=project.system.id %}" class="portfolio-project-link">{{project.title|truncatechars:60}}</a>
         </div>
 
         <div class="col-xs-6 col-sm-1">{{project.id}}</div>
@@ -75,7 +75,7 @@ Remove contextbar from top of page
         {% if perms.siteapp.delete_project %}
         <div class="col-xs-6 col-sm-2">Owner</div>
         {% elif perms.siteapp.change_project %}
-        <div class="col-xs-6 col-sm-2">Project Member</div>
+        <div class="col-xs-6 col-sm-2">Member</div>
         {% else %}
         <div class="col-xs-6 col-sm-2">Portfolio Member</div>
         {% endif %}

--- a/templates/project_settings.html
+++ b/templates/project_settings.html
@@ -261,7 +261,7 @@ h3.question-group-title {
 
 {% block body_content %}
     <div class="row">
-      <h2>Project Settings</h2>
+      <h2>System/Project Settings</h2>
     </div>
     <div class="row">
 

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -4,7 +4,7 @@
 {% load humanize %}
 
 {% block title %}
-Your Compliance Projects
+Systems
 {% endblock %}
 
 {% block head %}
@@ -108,7 +108,7 @@ Your Compliance Projects
   <a id="new-project-link-from-projects" href="{% url 'create_system_from_string' %}" class=" btn btn-success">New system</a>
 </div>
 
-<h2 class="">Projects</h2>
+<h2 class="">Systems</h2>
 
 <form action="{% url 'projects' %}" method="GET" role="search">
     <div class="form-inline pull-right create-nav">
@@ -135,7 +135,7 @@ Your Compliance Projects
   <p>&nbsp;</p>
   <div class="container">
   <div class="row">
-    <div class="col-xs-10 col-md-5"><strong>Project</strong></div>
+    <div class="col-xs-10 col-md-5"><strong>System</strong></div>
     <div class="col-xs-6 col-sm-1"><strong>ID</strong></div>
     <div class="col-xs-6 col-sm-4"><strong>Portfolio</strong></div>
     <div class="col-xs-12 col-md-2"><strong>Updated</strong></div>

--- a/templates/summary-horizontal-nav.html
+++ b/templates/summary-horizontal-nav.html
@@ -34,6 +34,7 @@
     <li><span class="material-symbols-outlined ">hub</span><span class="summary-nav-options"><a href="/systems/{{ system.id }}/aspen/deployments">Deployments</a></span></li>
     <!-- <li><span class="material-symbols-outlined ">article</span><span class="summary-nav-options">Artifacts</span></li> -->
     <li><span class="material-symbols-outlined ">hub</span><span class="summary-nav-options"><a href="/systems/{{ system.id }}/aspen/integrations">Integrations</a></span></li>
+    <li><span class="material-symbols-outlined ">hub</span><span class="summary-nav-options"><a href="/projects/{{ system.id }}/{{ system.name|slugify }}/settings">Settings</a></span></li>
   </ul>
 </div>
 </div>

--- a/templates/summary_navbar.html
+++ b/templates/summary_navbar.html
@@ -4,7 +4,8 @@
 
 .navbar-header { background-color:#fff;}
 .navbar { background-color:#fff; }
-
+.navbar-left >li>a { text-shadow: none; color: #666; }
+.navbar-right >li>a { text-shadow: none; color: #666; }
 
 </style>
 
@@ -28,11 +29,11 @@
     <div id="navbar-collapse-target" class="collapse navbar-collapse">
       <ul class="nav navbar-nav navbar-left">
         {% if request.user.is_authenticated and not request.user.is_anonymous %}
-        <!--  <li><a href="/projects" id="menu-projects">Projects</a></li>
+         <li><a href="/projects" id="menu-projects">Systems</a></li>
           <li><a href="/portfolios" id="menu-portfolios">Portfolios</a></li>
           <li><a href="/controls" id="menu-controls">Controls</a></li>
           <li><a href="{% url 'component_library' %}" id="menu-components">Component Library</a></li>
-          <li><a href="{% url 'store' %}" id="menu-templates">Template Library</a></li> -->
+          <li><a href="{% url 'store' %}" id="menu-templates">Template Library</a></li>
         {% endif %}
       </ul>
 
@@ -121,4 +122,5 @@
       </ul>
     </div><!-- /.navbar-collapse -->
   </div><!-- /.container-fluid -->
+  <div style="margin-top:8px; padding:0px 0px 0 0px; border-top:1px solid #ccc; background-color:#F5F5F5;"></div>
 </nav>

--- a/templates/systems/components_selected_aspen.html
+++ b/templates/systems/components_selected_aspen.html
@@ -22,7 +22,7 @@ System
 <style>
 </style>
 
-<div style="margin-top:8px; padding:20px 50px 0 50px; border-top:1px solid #ccc; background-color:#F5F5F5;">
+<div style="margin-top:8px; padding:20px 50px 0 50px; background-color:#F5F5F5;">
 <div class="row">
       <div class="col-md-8" style="">
           <h3 class="system-classification">{{ system_summary.impact }}</h3>

--- a/templates/systems/controls_selected_aspen.html
+++ b/templates/systems/controls_selected_aspen.html
@@ -22,7 +22,7 @@ System
 <style>
 </style>
 
-<div style="margin-top:8px; padding:20px 50px 0 50px; border-top:1px solid #ccc; background-color:#F5F5F5;">
+<div style="margin-top:8px; padding:20px 50px 0 50px; background-color:#F5F5F5;">
 <div class="row">
       <div class="col-md-8" style="">
           <h3 class="system-classification">{{ system_summary.impact }}</h3>

--- a/templates/systems/deployments_list_aspen.html
+++ b/templates/systems/deployments_list_aspen.html
@@ -22,7 +22,7 @@ System
 <style>
 </style>
 
-<div style="margin-top:8px; padding:20px 50px 0 50px; border-top:1px solid #ccc; background-color:#F5F5F5;">
+<div style="margin-top:8px; padding:20px 50px 0 50px; background-color:#F5F5F5;">
 <div class="row">
       <div class="col-md-8" style="">
           <h3 class="system-classification">{{ system.impact }}</h3>

--- a/templates/systems/new_system_form.html
+++ b/templates/systems/new_system_form.html
@@ -62,27 +62,54 @@
         </div> 
 
         <div class="col-md-3 portfolio-org-col ">
-            <h2>By Project Template</h2>
-            <p>Use a project template to start a new system.</p>
+            <h2>By Template</h2>
+            <p>Use a template to start a new system.</p>
         </div>
         <div class="col-md-9 portfolio-org-col ">
-            <div class="well" style="height: 140px;">
-                <div class="" style="display: block;float: left; border:0.5px solid #888; background-color: white; height: 100px; width:160px; margin-left:20px;">
-                    Default template
-                </div>
-                <div style="display: block;float: left; border:0.5px solid #888; background-color: white; height: 100px; width:160px; margin-left:20px;">
-                    Speedy SSP
-                </div>
-                <div style="display: block;float: left; border:0.5px solid #888; background-color: white; height: 100px; width:160px; margin-left:20px;">
-                    Network
-                </div>
+            <div class="well" style="height: 180px;">
+                {% for app_category in apps %}
+                    {% for app in app_category.apps %}
+                    <div class="col-lg-3 col-md-4 col-sm-6" >
+                        <div class="panel panel-default">
+                            <div class="panel-heading hidden">{{ app.title }}</div>
+                            <div class="panel-body app" style="" data-app="{{app.key}}" data-search-haystack="{{app.search_haystak}} {% if app_category.title %}{{app_category.title}}{% endif %}">
+                                <h3 class="app_store small" style="margin-top:0px;font-weight: bold;">{{ app.title|truncatechars_html:18 }}</h2>
+                                <h3 class="app_store small">{{app.description.short|safe|truncatechars_html:20}}</h3>
+                                <!-- <div class="app-version-info">Version: {{ app.version }}</div> -->
+                            </div>
+                            <div class="text-center" style="padding-bottom:1em;">
+                                <div style="display: inline-block;">
+                                    {# Offer quick start button if user can only start the app in a single organization context. #}
+                                    {% if app.organizations|length >= 1 %}
+                                        <form action="/store/{{ app.key|urlencode }}{{ forward_qsargs }}" method="post" style="display: inline-block;" class="app-form" data-app="{{app.key}}">
+                                          {% csrf_token %}
+                                          {% if app.organizations|length > 1 %}
+                                              <select id="app-org-select" class="" onchange="update_org_choice('{{ app.key }}/organization_{{ forloop.counter }}', event)">
+                                                  {% for org in app.organizations %}
+                                                      <option value="{{ org.slug }}">{{ org }}</option>
+                                                  {% endfor %}
+                                              </select>
+                                          {% endif %}
+                                          {% with app.organizations|first as first_org %}
+                                              <input type="hidden" id="{{ app.key }}/organization_{{ forloop.counter }}" name="organization" value="{{ first_org.slug }}">
+                                          {% endwith %}
+                                          {% if 'portfolio' in forward_qsargs %}{% endif %}
+                                            <button type="submit" class="btn btn-default btn-xs btn-justified start-app" style="width:150px; padding:.25em;">Start</button>
+                                        </form>
+                                    {% endif %}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    {% endfor %}
+                {% endfor %}
+
                 <div style="display: block;float: left; border:0.0px solid #888; height: 100px; width:160px; margin-left:20px;">
                     <p>&nbsp;</p>
                    <p><a href="{% url 'store' %}?start=true" role="link" style="color: #666;">More templates &gt;&gt;</a></p>
                 </div>
             </div>
         </div>
-
     </div>
 </div>
 

--- a/templates/systems/system_integrations_aspen.html
+++ b/templates/systems/system_integrations_aspen.html
@@ -19,7 +19,7 @@ System
 
 {% block body_content %}
 
-<div style="margin-top:8px; padding:20px 50px 0 50px; border-top:1px solid #ccc; background-color:#F5F5F5;">
+<div style="margin-top:8px; padding:20px 50px 0 50px; background-color:#F5F5F5;">
 <div class="row">
       <div class="col-md-8" style="">
           <h3 class="system-classification">{{ system.impact }}</h3>

--- a/templates/systems/system_summary_1.html
+++ b/templates/systems/system_summary_1.html
@@ -22,7 +22,7 @@ System
 <style>
 </style>
 
-<div style="margin-top:8px; padding:20px 50px 0 50px; border-top:1px solid #ccc; background-color:#F5F5F5;">
+<div style="margin-top:8px; padding:20px 50px 0 50px; background-color:#F5F5F5;">
 <div class="row">
       <div class="col-md-8" style="">
           <h3 class="system-classification">{{ system.impact }}</h3>


### PR DESCRIPTION
Switch to Aspen navbar
    
Switched to Aspen look and feel by switching to include Aspen's summary-navbar.html in base.html. Everything changed and looks great.

Properly display several default templates on the Aspen new system page. Various refactoring to support the display of these app templates, including setting the choice of default templates in the organization.extra json field.

Replace "Projects" in navigation and other screens with "Systems"

Add to Aspen system summary horizontal nav a link to system's settings page.

<img width="1555" alt="image" src="https://user-images.githubusercontent.com/24979/174711041-825d3ea4-1647-46f3-a91f-1c36b3c5443a.png">

<img width="1555" alt="image" src="https://user-images.githubusercontent.com/24979/174711551-fbe9e2e9-3165-4e13-b6d3-beebf8522245.png">


<img width="1555" alt="image" src="https://user-images.githubusercontent.com/24979/174710949-24d26de6-77ec-49ab-92df-ed8e4968ae03.png">

<img width="1555" alt="image" src="https://user-images.githubusercontent.com/24979/174710976-1c962a9e-5ed6-450b-a578-518eb5b5828e.png">

